### PR TITLE
Remove 'in-transition' at end of body transition

### DIFF
--- a/scripts/nomadic.js
+++ b/scripts/nomadic.js
@@ -20,8 +20,10 @@ function isModeLight() {
     return false;
 }
 
-function removeBodyTransition() {
-    let newBodyClass = body.className.replace('in-transition', '');
-    newBodyClass = newBodyClass.trim();
-    body.className = newBodyClass;
+function removeBodyTransition(ev) {
+    if (ev.propertyName == 'color' && ev.target.tagName.toLowerCase() == 'body') {
+        let newBodyClass = body.className.replace('in-transition', '');
+        newBodyClass = newBodyClass.trim();
+        body.className = newBodyClass;
+    }
 }

--- a/styles/nomadic.css
+++ b/styles/nomadic.css
@@ -10,7 +10,7 @@ body {
 }
 
 body.in-transition {
-    transition: color 0.5s cubic-bezier(.33, .66, .66, 1), background .3s cubic-bezier(.33, .66, .66, 1);
+    transition: color .5s cubic-bezier(.33, .66, .66, 1), background .3s cubic-bezier(.33, .66, .66, 1);
 }
 
 h1, h2, h3 {
@@ -38,7 +38,7 @@ a {
 }
 
 body.in-transition a {
-    transition: 0.5s cubic-bezier(.33, .66, .66, 1);
+    transition: .5s cubic-bezier(.33, .66, .66, 1);
     transition-property: border-bottom, box-shadow;
 }
 


### PR DESCRIPTION
removeBodyTransition() is called at the end of every transition
done inside of <body>. Add a check to only remove 'in-transition'
class from body if the event was from the end of the body's
transition after a mode change

- Remove '0.'s from css